### PR TITLE
add code monitoring setting ann config

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,16 @@
+# Monitoring 환경구성
+- Prometheus: 플렛폼 메트릭 수집
+- Grafana: 메트릭 시각화
+
+
+## server02
+- Spark 모니터링(Spark-exporter, * Spark docker-compose.yaml 참고)
+- Kafka 모니터링(Kafka-exporter)
+    - 카프카브로커 상태 및 debezium커넥터의 상태체크를 모니터링 할 목적으로 구성했지만, debezium커넥터 설정에 어려움이 있어, 카프카브로커 설정만 함.
+- 인스턴스 모니터링(node-exporter)
+
+
+
+## server04
+- 인스턴스 모니터링(node-exporter)
+    - server04는 모델 작업하는 서버로 서버 메모리 모니터링 필요에 따라 구성

--- a/monitoring/server02/docker-compose.yaml
+++ b/monitoring/server02/docker-compose.yaml
@@ -1,0 +1,52 @@
+# docker-compose.yaml
+services:
+  prometheus:
+    image: prom/prometheus:v2.43.0
+    container_name: prometheus
+    restart: always
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - ${NETWORK_NAME}
+
+  grafana:
+    image: grafana/grafana:10.1.1
+    container_name: grafana
+    restart: always
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+    ports:
+      - "3000:3000"
+    networks:
+      - ${NETWORK_NAME}
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+  kafka-exporter:
+    image: danielqsj/kafka-exporter:v1.6.0
+    container_name: kafka-exporter
+    command:
+      - '--kafka.server=kafka-2:9092'
+    ports:
+      - "9308:9308"
+    networks:
+      - ${NETWORK_NAME}
+    restart: always
+
+  node-exporter:
+    image: prom/node-exporter:v1.6.0
+    container_name: node-exporter
+    restart: always
+    ports:
+      - "9100:9100"
+    networks:
+      - ${NETWORK_NAME}
+
+networks:
+  ${NETWORK_NAME}:
+    external: true
+
+volumes:
+  grafana_data:

--- a/monitoring/server02/prometheus.yml
+++ b/monitoring/server02/prometheus.yml
@@ -1,0 +1,41 @@
+# promethus.yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'node'
+    static_configs:
+      - targets: ['172.31.2.37:9100']
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'node_(cpu|memory|disk|filesystem|network).*'
+        action: keep
+
+  - job_name: 'kafka'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['172.31.2.37:9308']
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'kafka_.*'
+        action: keep
+
+  - job_name: 'spark_master_native'
+    metrics_path: '/metrics/master/prometheus'
+    static_configs:
+      - targets: ['172.31.3.183:8085']
+
+  - job_name: 'spark_applications_native'
+    metrics_path: '/metrics/applications/prometheus'
+    static_configs:
+      - targets: ['172.31.3.183:8085']
+
+  - job_name: 'spark_worker-1_native'
+    metrics_path: '/metrics/worker/prometheus'
+    static_configs:
+      - targets: ['172.31.2.37:8086']
+
+  - job_name: 'spark_worker-2_native'
+    metrics_path: '/metrics/worker/prometheus'
+    static_configs:
+      - targets: ['172.31.0.17:8087']

--- a/monitoring/server04/docker-compose.yaml
+++ b/monitoring/server04/docker-compose.yaml
@@ -1,0 +1,27 @@
+# docker-compose.yaml
+services:
+  prometheus:
+    image: prom/prometheus:v2.43.0
+    container_name: prometheus
+    restart: always
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring-network
+
+  node-exporter:
+    image: prom/node-exporter:v1.6.0
+    container_name: node-exporter
+    restart: always
+    ports:
+      - "9100:9100"
+    networks:
+      - monitoring-network
+
+networks:
+  monitoring-network:
+    name: monitoring-network
+    driver: bridge
+

--- a/monitoring/server04/promethus.yaml
+++ b/monitoring/server04/promethus.yaml
@@ -1,0 +1,12 @@
+# promethus.yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'node'
+    static_configs:
+      - targets: ['172.31.15.63:9100']
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'node_(cpu|memory|disk|filesystem|network).*'
+        action: keep


### PR DESCRIPTION
# Monitoring 환경구성
- Prometheus: 플렛폼 메트릭 수집
- Grafana: 메트릭 시각화


## server02
- Spark 모니터링(Spark-exporter, * Spark docker-compose.yaml 참고)
- Kafka 모니터링(Kafka-exporter)
    - 카프카브로커 상태 및 debezium커넥터의 상태체크를 모니터링 할 목적으로 구성했지만, debezium커넥터 설정에 어려움이 있어, 카프카브로커 설정만 함.
- 인스턴스 모니터링(node-exporter)



## server04
- 인스턴스 모니터링(node-exporter)
    - server04는 모델 작업하는 서버로 서버 메모리 모니터링 필요에 따라 구성
